### PR TITLE
Subject: kbuild: Fix 'patch_kpm' script execution when srctree is rel…

### DIFF
--- a/patches/02-add-auto-kpm-patch.patch
+++ b/patches/02-add-auto-kpm-patch.patch
@@ -7,7 +7,6 @@ index 6986f77cc..f578a121c 100644
  $(obj)/Image: vmlinux FORCE
  	$(call if_changed,objcopy)
 +ifeq ($(CONFIG_KPM),y)
-+	$(Q)cd $(obj) &&
-+ $(Q)$(srctree)/scripts/patch_kpm
++	$(Q)cd $(obj) && $(realpath $(srctree))/scripts/patch_kpm
 +	$(Q)mv -f $(obj)/oImage $@
 +endif


### PR DESCRIPTION
…ative

When `srctree` is a relative path (e.g., `..`), the command `$(Q)cd $(obj) && $(srctree)/scripts/patch_kpm` can fail to locate and execute the `patch_kpm` script. This occurs because after changing directory to `$(obj)`, the relative path for `srctree` may no longer correctly resolve to the kernel source tree root.

To fix this, ensure that `$(srctree)` is always resolved to an absolute path before being used to construct the script's path. This can be achieved by using `$(realpath $(srctree))`. This guarantees that even if `srctree` is initially a relative path like `..`, the resulting path to `patch_kpm` will be an absolute one, allowing the script to be found and executed correctly regardless of the current working directory after `cd $(obj)`.